### PR TITLE
Replace deprecated addListener with the normal addEventListener and a change event

### DIFF
--- a/browser-window.js
+++ b/browser-window.js
@@ -183,7 +183,7 @@ class BrowserWindow extends HTMLElement {
 		if(!this.hasAttribute(BrowserWindow.attrs.mode)) {
 			this.setMode(prefersDarkMode.matches);
 
-			prefersDarkMode.addListener(e => {
+			prefersDarkMode.addEventListener('change', e => {
 				this.setMode(e.matches);
       });
 		}


### PR DESCRIPTION
`MediaQuery.addListener` is deprecated, tiny change to update to a change event instead 😄 

From MDN:

> Use addEventListener() instead of addListener() if it is available in the browsers you need to support.

[addListener on MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener)